### PR TITLE
Renamed output executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
   - cd bitstreams
   - git checkout b19d683
   - cd ..
-  - ./turing/turing-exe signature ../test/
-  - ./turing/turing-exe testdecode
+  - ./turing/turing signature ../test/
+  - ./turing/turing testdecode

--- a/havoc/.travis.yml
+++ b/havoc/.travis.yml
@@ -27,6 +27,5 @@ script:
   - cd build
   - cmake -DCMAKE_CXX_COMPILER=g++-5 -DCMAKE_C_COMPILER=gcc-5 ..
   - make
-  - sde64 -nhm -- ./havoc-exe --no-measure-speed
-  - sde64 -hsw -- ./havoc-exe --no-measure-speed
-
+  - sde64 -nhm -- ./havoc --no-measure-speed
+  - sde64 -hsw -- ./havoc --no-measure-speed

--- a/havoc/CMakeLists.txt
+++ b/havoc/CMakeLists.txt
@@ -52,4 +52,6 @@ add_executable(havoc-exe
 
 target_link_libraries(havoc-exe havoc)
 
+set_target_properties(havoc-exe PROPERTIES OUTPUT_NAME havoc)
+
 install(TARGETS havoc LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)

--- a/turing/CMakeLists.txt
+++ b/turing/CMakeLists.txt
@@ -44,7 +44,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COMPILE_FLAGS}")
     set(LINK_LIBRARIES ${LINK_LIBRARIES} rt)
-endif (CMAKE_COMPILER_IS_GNUCC	)
+endif (CMAKE_COMPILER_IS_GNUCC)
 
 set(SEI_HEADERS
     sei/ReadSei.h
@@ -205,7 +205,9 @@ source_group(SEI FILES ${SEI_HEADERS})
 
 target_link_libraries (turing LINK_PUBLIC havoc)
 
-add_executable (turing-exe main.cpp )
+add_executable (turing-exe main.cpp)
+
+set_target_properties(turing-exe PROPERTIES OUTPUT_NAME turing)
 
 target_link_libraries (turing-exe LINK_PUBLIC turing ${LINK_LIBRARIES})
 

--- a/turing/main.cpp
+++ b/turing/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, const char *argv[])
     {
         if (arguments.size() == 2) return help(arguments[0], false);
 
-        // translate "turing-exe help command" to "turing-exe command --help"
+        // translate "turing help command" to "turing command --help"
         arguments.resize(3);
         command = arguments[1] = arguments[2];
         arguments[2] =  "--help";

--- a/turing/testdecode.cpp
+++ b/turing/testdecode.cpp
@@ -18,7 +18,7 @@ the Turing codec are also available under a proprietary license.
 For more information, contact us at info @ turingcodec.org.
  */
 
-// Self-test code relating to the "turing-exe testdecode" command.
+// Self-test code relating to the "turing testdecode" command.
 
 #include "ConformanceStreams.h"
 #include <boost/program_options.hpp>


### PR DESCRIPTION
This pull request addresses issue #8:

- Renamed executable turing-exe to turing
- Renamed executable havoc-exe to havoc
- Updated Travis CI config to use the new filenames

Note that the havoc changes should probably be pushed to the upstream project.

I have tested locally on Ubuntu 16.04 and Windows with Visual Studio Express 2015.